### PR TITLE
chore(dev): add script to generate clangd cfg

### DIFF
--- a/.github/dev/generate_clangd_cfg.sh
+++ b/.github/dev/generate_clangd_cfg.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -e
+set -u
+set -o pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+C_DIR="$REPO_ROOT/src/c"
+
+echo "Generating compile_commands.json using bear..."
+
+# Ensure bear is installed
+if ! command -v bear &> /dev/null; then
+    echo "Error: 'bear' is not installed. Install it with 'sudo apt install bear' or 'brew install bear'." >&2
+    exit 1
+fi
+
+(
+    cd "$C_DIR"
+    bear -- make clean
+    bear -- make
+)
+
+mv "$C_DIR/compile_commands.json" "$REPO_ROOT/"
+
+echo "compile_commands.json has been placed in the repository root."

--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,18 @@
+# python stuff
 **/__pycache__/
 **/*.egg-info
 *.pyc
 .pytest_cache/
 .ruff_cache/
-
 venv/
 
-**/.DS_Store
-
-.zed
-
+# C stuff
+*.cache
 *.out
+
+# Editor specific stuff
+.zed
+compile_commands.json
+
+# OS specific stuff
+**/.DS_Store


### PR DESCRIPTION
Adds script to generate `compile_commands.json` using `bear`. Also added a note in the wiki